### PR TITLE
Mon dependency pymicmac

### DIFF
--- a/pycoeman/monitor/plot_disk.py
+++ b/pycoeman/monitor/plot_disk.py
@@ -2,7 +2,7 @@
 import os, argparse
 import matplotlib.pyplot as plt
 import numpy
-from pymicmac import utils_execution
+from pycoeman import utils_execution
 
 def run(inputArgument, outputFile):
     if outputFile != None:

--- a/pycoeman/utils_execution.py
+++ b/pycoeman/utils_execution.py
@@ -1,6 +1,37 @@
- #!/usr/bin/python
+#!/usr/bin/python
 import os
 from pycoeman.monitor import monitor_cpu_mem_disk
+import os,subprocess
+from lxml import etree
+
+def readGCPXMLFile(xmlFile):
+    gcpsXYZ = {}
+    cpsXYZ = {}
+
+    if not os.path.isfile(xmlFile):
+        raise Exception('ERROR: ' + xmlFile + ' not found')
+
+    e = etree.parse(xmlFile).getroot()
+    for p in e.getchildren():
+        gcp = p.find('NamePt').text
+        fields = p.find('Pt').text.split()
+        incertitude = p.find('Incertitude').text
+
+        x = float(fields[0])
+        y = float(fields[1])
+        z = float(fields[2])
+        if incertitude.count('-1'):
+            cpsXYZ[gcp] = (x, y, z)
+        else:
+            gcpsXYZ[gcp] = (x, y, z)
+    return (gcpsXYZ, cpsXYZ)
+
+def getSize(absPath):
+    (out,err) = subprocess.Popen('du -sb ' + absPath, shell = True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+    try:
+        return int(out.split()[0])
+    except:
+        return -1
 
 def executeCommandMonitor(commandId, command, diskPath, onlyPrint=False):
     # Define the names of the script that executes the command, the log file and the monitor file

--- a/pycoeman/utils_execution.py
+++ b/pycoeman/utils_execution.py
@@ -1,14 +1,6 @@
 #!/usr/bin/python
 import os
 from pycoeman.monitor import monitor_cpu_mem_disk
-import os,subprocess
-
-def getSize(absPath):
-    (out,err) = subprocess.Popen('du -sb ' + absPath, shell = True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-    try:
-        return int(out.split()[0])
-    except:
-        return -1
 
 def executeCommandMonitor(commandId, command, diskPath, onlyPrint=False):
     # Define the names of the script that executes the command, the log file and the monitor file

--- a/pycoeman/utils_execution.py
+++ b/pycoeman/utils_execution.py
@@ -2,29 +2,6 @@
 import os
 from pycoeman.monitor import monitor_cpu_mem_disk
 import os,subprocess
-from lxml import etree
-
-def readGCPXMLFile(xmlFile):
-    gcpsXYZ = {}
-    cpsXYZ = {}
-
-    if not os.path.isfile(xmlFile):
-        raise Exception('ERROR: ' + xmlFile + ' not found')
-
-    e = etree.parse(xmlFile).getroot()
-    for p in e.getchildren():
-        gcp = p.find('NamePt').text
-        fields = p.find('Pt').text.split()
-        incertitude = p.find('Incertitude').text
-
-        x = float(fields[0])
-        y = float(fields[1])
-        z = float(fields[2])
-        if incertitude.count('-1'):
-            cpsXYZ[gcp] = (x, y, z)
-        else:
-            gcpsXYZ[gcp] = (x, y, z)
-    return (gcpsXYZ, cpsXYZ)
 
 def getSize(absPath):
     (out,err) = subprocess.Popen('du -sb ' + absPath, shell = True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()

--- a/tests/run_parcommands_local_test.sh
+++ b/tests/run_parcommands_local_test.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-python ../pycoeman/parcommands/run_parcommands_local.py -d . -e parcommands_local_test_exe -c parcommands_test.xml -n 2
+coeman-par-local -d . -e parcommands_local_test_exe -c parcommands_test.xml -n 2

--- a/tests/run_parcommands_sge_cluster_test.sh
+++ b/tests/run_parcommands_sge_cluster_test.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-python ../pycoeman/parcommands/run_parcommands_sge_cluster/run_parcommands_sge_jobs.py -d . -c parcommands_test.xml -s /home/orubi/improphoto/export_paths.sh -r /local/orubi/TestPycoeman -o parcommands_sge_cluster_test_out
+coeman-par-sge -d . -c parcommands_test.xml -s /home/orubi/improphoto/export_paths.sh -r /local/orubi/TestPycoeman -o parcommands_sge_cluster_test_out

--- a/tests/run_parcommands_ssh_test.sh
+++ b/tests/run_parcommands_ssh_test.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-python ../pycoeman/parcommands/run_parcommands_ssh.py -d . -e parcommands_ssh_test_exe -c parcommands_test.xml -r hosts.xml -o parcommands_ssh_test_out
+coeman-par-ssh -d . -e parcommands_ssh_test_exe -c parcommands_test.xml -r hosts.xml -o parcommands_ssh_test_out

--- a/tests/run_seqcommands_local_test.sh
+++ b/tests/run_seqcommands_local_test.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-python ../pycoeman/seqcommands/run_seqcommands_local.py -d . -e seqcommands_local_test_exe -c seqcommands_test.xml
+coeman-seq-local -d . -e seqcommands_local_test_exe -c seqcommands_test.xml


### PR DESCRIPTION
Solve the dependency on pymicmac.
The tests should use the commands installed by the package and not call python directly because then we have issues with Python version.